### PR TITLE
Tag each tick w/ the actual value to use in lookup.  Insead of always…

### DIFF
--- a/src/js/bootstrap-slider.js
+++ b/src/js/bootstrap-slider.js
@@ -526,6 +526,7 @@ const windowIsDefined = (typeof window === "object");
 					for (i = 0; i < this.options.ticks.length; i++) {
 						var tick = document.createElement('div');
 						tick.className = 'slider-tick';
+						tick.setAttribute('data-value', this.options.ticks[i]);
 						if (this.options.ticks_tooltip) {
 							var tickListenerReference = this._addTickListener();
 							var enterCallback = tickListenerReference.addMouseEnter(this, tick, i);
@@ -1632,7 +1633,7 @@ const windowIsDefined = (typeof window === "object");
 				document.addEventListener("mouseup", this.mouseup, false);
 
 				this._state.inDrag = true;
-				var newValue = this._calculateValue();
+				var newValue = this._calculateValue(ev);
 
 				this._trigger('slideStart', newValue);
 
@@ -1764,7 +1765,7 @@ const windowIsDefined = (typeof window === "object");
 				this._adjustPercentageForRangeSliders(percentage);
 				this._state.percentage[this._state.dragged] = percentage;
 
-				var val = this._calculateValue(true);
+				var val = this._calculateValue(ev, true);
 				this.setValue(val, true, true);
 
 				return false;
@@ -1825,7 +1826,7 @@ const windowIsDefined = (typeof window === "object");
 				if (this._state.over === false) {
 					this._hideTooltip();
 				}
-				var val = this._calculateValue(true);
+				var val = this._calculateValue(ev, true);
 
 				this.setValue(val, false, true);
 				this._trigger('slideStop', val);
@@ -1842,7 +1843,7 @@ const windowIsDefined = (typeof window === "object");
 					val.data[index] = this._applyPrecision(val.data[index]);
 				}
 			},
-			_calculateValue: function(snapToClosestTick) {
+			_calculateValue: function(ev, snapToClosestTick) {
 				let val = {};
 				if (this.options.range) {
 					val.data = [this.options.min, this.options.max];
@@ -1852,6 +1853,8 @@ const windowIsDefined = (typeof window === "object");
 						val.data[0] = this._snapToClosestTick(val.data[0]);
 						val.data[1] = this._snapToClosestTick(val.data[1]);
 					}
+				} else if (ev && ev.target && ev.target.getAttribute('data-value') !== null) {
+					val.data = parseFloat(ev.target.getAttribute('data-value'));
 				} else {
 					val.data = this._toValue(this._state.percentage[0]);
 					val.data = parseFloat(val.data);


### PR DESCRIPTION
… relying on % along the slider to come up w/ the final value.

@mpiannucci

Default behavior of the slider is to compute where a user has clicked based on how far along the slider the event occurs.  For FMIS, where we explicitly list the available times, take the guesswork away by tagging each tick w/ the actual value.  And have the callback use the value instead of how far along the track it clicked.  For non-gettimestamps distros, no effect.

Will help w/ https://github.com/asascience/FMIS/issues/470.